### PR TITLE
Tracker Issue and Logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "rl-hours-tracker"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "build_html",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rl-hours-tracker"
 license = "MIT"
-version = "0.4.3"
+version = "0.4.4"
 documentation = "https://docs.rs/crate/rl-hours-tracker"
 repository = "https://github.com/OneilNvM/rl-hours-tracker"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 </p>
 
 <p align="center">
-    <a href="https://crates.io/crates/rl-hours-tracker/0.4.3" target="_blank">
-        <img alt="Static Badge" src="https://img.shields.io/badge/crates.io-v0.4.3-blue?logo=rust">
+    <a href="https://crates.io/crates/rl-hours-tracker/0.4.4" target="_blank">
+        <img alt="Static Badge" src="https://img.shields.io/badge/crates.io-v0.4.4-blue?logo=rust">
     </a>
-    <a href="https://github.com/OneilNvM/rl-hours-tracker/releases/tag/v0.4.3" target="_blank">
-        <img alt="Static Badge" src="https://img.shields.io/badge/Release-v0.4.3-purple?logo=github">
+    <a href="https://github.com/OneilNvM/rl-hours-tracker/releases/tag/v0.4.4" target="_blank">
+        <img alt="Static Badge" src="https://img.shields.io/badge/Release-v0.4.4-purple?logo=github">
     </a>
 </p>
 


### PR DESCRIPTION
Fixed an issue which caused the tracker to instantly end once started.

Added additional functionality to allow for the event_loop for the system tray icon to be cleared when exiting the main loop of the tracker program.

Added more logging for the winit_tray_icon module and library as well as trace level logging.